### PR TITLE
remove orders after 100 failed attempts

### DIFF
--- a/keeper.ts
+++ b/keeper.ts
@@ -151,7 +151,7 @@ async function main() {
                             deleteOrder(order.account);
                         }
                         txQueue.delete(order.account);
-                        console.log('ERROR:', order.account, e);
+                        console.log('FAILED attempts:', order.failures, 'Account:', order.account);
                     }
                 }
             }


### PR DESCRIPTION
To avoid orders being dropped while circuit breaker is in action, raise the attempts from 10 to 100 before removing an order.